### PR TITLE
Expand reportTokenToServer with callback

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -109,7 +109,15 @@ Push.setMetadata = function (data) {
   }
 };
 
-// Report token to the server
+/*
+  Report token to the server.
+  @param token value of the fcmToken
+  @param appName name of the application that token was created for
+  @param platform determines the type of application that
+  the token was created on e.g. browser
+  @param callback function to be invoked if there were
+  no errors thrown in raix:push-update
+ */
 Push.reportTokenToServer = function (token, appName, platform, callback) {
   // Store the token
   stored.token = token;

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -110,7 +110,7 @@ Push.setMetadata = function (data) {
 };
 
 // Report token to the server
-Push.reportTokenToServer = function (token, appName, platform) {
+Push.reportTokenToServer = function (token, appName, platform, callback) {
   // Store the token
   stored.token = token;
 
@@ -145,6 +145,11 @@ Push.reportTokenToServer = function (token, appName, platform) {
       // Make sure enabled is also updated to keep in sync
       if (typeof result.enabled !== 'undefined') {
         _setEnabled(result.enabled);
+      }
+
+      // Invoke callback if the callback argument is provided
+      if (callback) {
+        callback();
       }
     }
   });


### PR DESCRIPTION
[Ticket](https://gitlab.com/vetsource/vs/-/issues/10637)

`reportTokenToServer` function has been modified and callback function can be passed as an argument. This callback is supposed to be ran after the successfull execution of underlying mechanism in that method.